### PR TITLE
Fix validation: POST /api/reminders now rejects empty body

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,9 +26,16 @@ app.get("/api/reminders", (req, res) => {
 // Add reminder
 app.post("/api/reminders", (req, res) => {
   const { title, date } = req.body;
+
+  // NEW VALIDATION FIX
+  if (!title || !date) {
+    return res.status(400).json({ error: "title and date are required" });
+  }
+
   const newReminder = reminders.add(title, date);
   res.json(newReminder);
 });
+
 
 // Edit reminder
 app.put("/api/reminders/:id", (req, res) => {

--- a/tests/reminders.functional.test.js
+++ b/tests/reminders.functional.test.js
@@ -85,11 +85,22 @@ describe("Reminder API - Functional Tests", () => {
   });
 
   test("POST /api/reminders requires title and date", async () => {
-    
-    const resNoData = await request(app)
-      .post("/api/reminders")
-      .send({});
+  const res = await request(app)
+    .post("/api/reminders")
+    .send({});
 
-    expect(resNoData.statusCode).toBe(200);
-  });
+  expect(res.statusCode).toBe(400);
+  expect(res.body).toHaveProperty("error");
+});
+
+test("POST /api/reminders rejects missing fields", async () => {
+  const res = await request(app)
+    .post("/api/reminders")
+    .send({ title: "" });
+
+  expect(res.statusCode).toBe(400);
+  expect(res.body).toHaveProperty("error");
+});
+
+
 });


### PR DESCRIPTION
Fixes #4 

### Summary
Added missing validation logic to ensure reminders cannot be created with empty or incomplete data.

### Changes
- Added title/date validation in POST /api/reminders
- Updated functional test to expect 400 instead of 200
- Added additional missing-field test case
- All tests passing locally

### Governance
- Issue created and documented
- Branch created following naming conventions
- Code updated per acceptance criteria
- Reviewer will complete /docs/CODE_REVIEW_TEMPLATE.md
- Merge into staging after approval
